### PR TITLE
Adopt image name splitting logic from docker

### DIFF
--- a/src/rocker/imagename/imagename.go
+++ b/src/rocker/imagename/imagename.go
@@ -59,12 +59,13 @@ func NewFromString(image string) *ImageName {
 // New parses a given 'image' and 'tag' strings and returns ImageName
 func New(image string, tag string) *ImageName {
 	dockerImage := &ImageName{}
-	if strings.Contains(image, ".") || len(strings.SplitN(image, "/", 3)) > 2 {
-		registryAndName := strings.SplitN(image, "/", 2)
-		dockerImage.Registry = registryAndName[0]
-		dockerImage.Name = registryAndName[1]
-	} else {
+	nameParts := strings.SplitN(image, "/", 2)
+	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
+		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
 		dockerImage.Name = image
+	} else {
+		dockerImage.Registry = nameParts[0]
+		dockerImage.Name = nameParts[1]
 	}
 	if tag != "" {
 		dockerImage.SetTag(tag)

--- a/src/rocker/imagename/imagename_test.go
+++ b/src/rocker/imagename/imagename_test.go
@@ -161,8 +161,8 @@ func TestImageRealLifeNamingExampleWithCapi(t *testing.T) {
 
 func TestImageParsingWithNamespace(t *testing.T) {
 	img := NewFromString("hub/ns/name:1")
-	assert.Equal(t, "hub", img.Registry)
-	assert.Equal(t, "ns/name", img.Name)
+	assert.Equal(t, "", img.Registry)
+	assert.Equal(t, "hub/ns/name", img.Name)
 	assert.Equal(t, "1", img.Tag)
 }
 
@@ -173,6 +173,24 @@ func TestImageParsingWithoutTag(t *testing.T) {
 	assert.Equal(t, "latest", img.GetTag())
 	assert.Equal(t, false, img.HasTag())
 	assert.Equal(t, "repo/name:latest", img.String())
+}
+
+func TestImageWithDotsWithoutTag(t *testing.T) {
+	img := NewFromString("a.b.c.d")
+	assert.Equal(t, "", img.Registry)
+	assert.Equal(t, "a.b.c.d", img.Name)
+	assert.Equal(t, "latest", img.GetTag())
+	assert.Equal(t, false, img.HasTag())
+	assert.Equal(t, "a.b.c.d:latest", img.String())
+}
+
+func TestImageWithDotsWithTag(t *testing.T) {
+	img := NewFromString("a.b.c.d:snapshot")
+	assert.Equal(t, "", img.Registry)
+	assert.Equal(t, "a.b.c.d", img.Name)
+	assert.Equal(t, "snapshot", img.GetTag())
+	assert.Equal(t, true, img.HasTag())
+	assert.Equal(t, "a.b.c.d:snapshot", img.String())
 }
 
 func TestImageLatest(t *testing.T) {


### PR DESCRIPTION
References:
- https://github.com/docker/docker/blob/master/api/client/tag.go#L22-L30
- https://github.com/docker/docker/blob/master/pkg/parsers/parsers.go#L100-L118
- https://github.com/docker/docker/blob/a1c373197fe7f865ccac0ad338c213e3d1f863de/registry/config.go#L240-L251
- https://github.com/docker/docker/blob/a1c373197fe7f865ccac0ad338c213e3d1f863de/registry/config.go#L285-L300

Also, one of the tests was invalid, cause "hub" is not a valid registry.
This can be checked by running this in command line:

```bash
$ docker tag ubuntu hub/ns/name:1
~/Projects/github/rocker 0 (tags-with-dots +) $ docker push hub/ns/name:1
The push refers to a repository [docker.io/hub/ns/name] (len: 1)
91e54dfb1179: Buffering to Disk
unauthorized: access to the requested resource is not authorized
```