### PR TITLE
Fixed issue #16. Cannot ^C while pulling an image

### DIFF
--- a/src/rocker/build/client.go
+++ b/src/rocker/build/client.go
@@ -310,6 +310,10 @@ func (c *DockerClient) RunContainer(containerID string, attachStdin bool) error 
 
 	signal.Notify(sigch, os.Interrupt)
 
+	/* Signal handler should be reset right after exit of this scope.
+	We don't want this sighanler to stay alive and suppress default signal handler if any*/
+	defer signal.Stop(sigch)
+
 	go func() {
 		statusCode, err := c.client.WaitContainer(containerID)
 		// c.log.Debugf("Wait finished, status %q error %q", statusCode, err)

--- a/src/rocker/build/client.go
+++ b/src/rocker/build/client.go
@@ -310,8 +310,8 @@ func (c *DockerClient) RunContainer(containerID string, attachStdin bool) error 
 
 	signal.Notify(sigch, os.Interrupt)
 
-	/* Signal handler should be reset right after exit of this scope.
-	We don't want this sighanler to stay alive and suppress default signal handler if any*/
+	// Signal handler should be reset right after exit of this scope.
+	// We don't want this sighanler to stay alive and suppress default signal handler if any
 	defer signal.Stop(sigch)
 
 	go func() {


### PR DESCRIPTION
 Will reset signal handler at function scope exit.
 This will allow to return default sighandler if any.