### PR TITLE
go build with '-ldflags' (with revisions) for 'default' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PKGS := $(foreach pkg, $(sort $(dir $(SRCS))), $(pkg))
 TESTARGS ?=
 
 default:
-	GO15VENDOREXPERIMENT=1 go build -v
+	GO15VENDOREXPERIMENT=1 go build -ldflags "-X main.Version=$(VERSION) -X main.GitCommit=$(GITCOMMIT) -X main.GitBranch=$(GITBRANCH) -X main.BuildTime=$(BUILDTIME)" -v
 
 install:
 	cp rocker /usr/local/bin/rocker


### PR DESCRIPTION
so that with a simple `make` (with the `default` target) command, we have the version and git revisions in the bin as well.
```
rocker --version
rocker version 1.2.0 - 98fe4ac (dev-mine) 2016-06-18_00:25_GMT
```