### PR TITLE
Warn about implicit contextDir change

### DIFF
--- a/main.go
+++ b/main.go
@@ -296,6 +296,8 @@ func buildCommand(c *cli.Context) {
 		if !filepath.IsAbs(contextDir) {
 			contextDir = filepath.Join(wd, args[0])
 		}
+	} else if contextDir != wd {
+		log.Warningf("Default context directory is %s. You can specify context direcotry as the last argument.", contextDir)
 	}
 
 	log.Debugf("Context directory: %s", contextDir)

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func buildCommand(c *cli.Context) {
 			contextDir = filepath.Join(wd, args[0])
 		}
 	} else if contextDir != wd {
-		log.Warningf("Default context directory is %s. You can specify context direcotry as the last argument.", contextDir)
+		log.Warningf("Implicit context directory used: %s. You can override context directory using the last argument.", contextDir)
 	}
 
 	log.Debugf("Context directory: %s", contextDir)


### PR DESCRIPTION
© @ybogdanov 

> Why is the default behavior taking base dir of Rockerfile instead of a current working directory? Because this behavior is more intuitive than the opposite. You can run a Rockerfile from any directory while keeping its functionality without a need to specify the context directory repetitively. Docker solves the latter by making the last argument mandatory.
> But yes, it's a good idea of making a warning if a base directory of Rockerfile is not same as current and the last argument is not specified explicitly.