### PR TITLE
Fix mount loop processing to avoid crash on invalid path

### DIFF
--- a/src/dockerclient/matrix.go
+++ b/src/dockerclient/matrix.go
@@ -78,7 +78,7 @@ func ResolveHostPath(mountPath string, client *docker.Client, isUnixSocket bool,
 	for _, mount := range container.Mounts {
 		rel, err := filepath.Rel(mount.Destination, mountPath)
 		if err != nil {
-			return "", err
+			continue
 		}
 		// The easiest way to check whether the `mountPath` is within the `mount.Destination`
 		if !strings.HasPrefix(rel, "..") {


### PR DESCRIPTION
Instead of leaving the loop when an invalid path is encountered, I ignore it and pass to the next one.