### PR TITLE
Fix matrix check for Docker 1.12

### DIFF
--- a/src/dockerclient/matrix.go
+++ b/src/dockerclient/matrix.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	initFile = "/.dockerinit"
+	initFile1 = "/.dockerinit"
+	initFile2 = "/.dockerenv"
 )
 
 // ErrDriverNotSupported is an error type that is returned if it's impossible to
@@ -123,11 +124,24 @@ func ResolveHostPath(mountPath string, client *docker.Client, isUnixSocket bool,
 
 // IsInMatrix returns true if current process is running inside of a docker container
 func IsInMatrix() (bool, error) {
-	_, err := os.Stat(initFile)
-	if err != nil && os.IsNotExist(err) {
-		return false, nil
+	fileExists := func(f string) (exists bool, err error) {
+		_, err = os.Stat(f)
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return err == nil, err
 	}
-	return true, err
+
+	f1, err := fileExists(initFile1)
+	if err != nil {
+		return false, err
+	}
+	f2, err := fileExists(initFile2)
+	if err != nil {
+		return false, err
+	}
+
+	return f1 || f2, nil
 }
 
 // getMyDockerID returns id of the current container the process is running within, if any

--- a/src/dockerclient/matrix.go
+++ b/src/dockerclient/matrix.go
@@ -149,8 +149,9 @@ func getMyDockerID() (string, error) {
 	if _, err := os.Stat("/proc/self/cgroup"); os.IsNotExist(err) {
 		return "", nil
 	}
+	// TODO: don't use sh, read file from Golang
 	output, exitStatus, err := util.ExecPipe(&util.Cmd{
-		Args: []string{"/bin/bash", "-c", `cat /proc/self/cgroup | grep "docker" | sed s/\\//\\n/g | tail -1`},
+		Args: []string{"/bin/sh", "-c", `cat /proc/self/cgroup | grep "cpu:/" | sed 's/\([0-9]\):cpu:\/docker\///g'`},
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Docker changed it's file name since 1.12, so we need to check whether we are in "matrix" differently. Ideally, we need to make a test for this, but no time, sorry.
