### PR TITLE
Improve ARG (--build-arg) to match Docker's behavior

### DIFF
--- a/test/buildarg_test.go
+++ b/test/buildarg_test.go
@@ -116,3 +116,119 @@ RUN env`
 		t.Fatal(err)
 	}
 }
+
+func TestBuildArg_FallbackEnv_NoValue(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE="},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_FallbackEnv_ArgDefault(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN=arg-default
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE=arg-default"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_FallbackEnv_CliOverride_NoEnv(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN=arg-default
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--build-arg", "NPM_TOKEN=cli-value", "--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE=cli-value"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_FallbackEnv_CliOverride_HasEnv(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN=arg-default
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--build-arg", "NPM_TOKEN=cli-value", "--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE=cli-value"},
+		env:               rockerBuildEnv("NPM_TOKEN=env-value"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_FallbackEnv_CliOmitValue_NoEnv(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN=arg-default
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--build-arg", "NPM_TOKEN", "--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE="},
+		env:               rockerBuildEnv(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_FallbackEnv_CliOmitValue_HasEnv1(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN=arg-default
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--build-arg", "NPM_TOKEN", "--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE=env-value"},
+		env:               rockerBuildEnv("NPM_TOKEN=env-value"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_FallbackEnv_CliOmitValue_ForceNoValue(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG NPM_TOKEN=arg-default
+RUN echo NPM_TOKEN_VALUE=$NPM_TOKEN`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--build-arg", "NPM_TOKEN=", "--no-cache", "--no-garbage"},
+		testLines:         []string{"NPM_TOKEN_VALUE="},
+		env:               rockerBuildEnv("NPM_TOKEN=env-value"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/buildarg_test.go
+++ b/test/buildarg_test.go
@@ -82,3 +82,37 @@ RUN export | grep proxy`
 
 	assert.NotEqual(t, sha1, sha2, "different build-arg values should invalidate cache")
 }
+
+func TestBuildArg_EnvSubstitute1(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG deployenv=development
+ENV DEPLOY_ENVIRONMENT=$deployenv
+RUN env`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--no-cache", "--no-garbage"},
+		testLines:         []string{"DEPLOY_ENVIRONMENT=development"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildArg_EnvSubstitute2(t *testing.T) {
+	rockerfileContent := `
+FROM alpine
+ARG deployenv=development
+ENV DEPLOY_ENVIRONMENT=$deployenv
+RUN env`
+
+	err := runRockerBuildWithOptions(rockerBuildOptions{
+		rockerfileContent: rockerfileContent,
+		buildParams:       []string{"--build-arg", "deployenv=uat", "--no-cache", "--no-garbage"},
+		testLines:         []string{"DEPLOY_ENVIRONMENT=uat"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -37,10 +37,15 @@ type cmdOptions struct {
 	args    []string
 	workdir string
 	stdout  io.Writer
+	env     []string
 }
 
 func runCmdWithOptions(opts cmdOptions) (string, error) {
 	cmd := exec.Command(opts.command, opts.args...)
+
+	if opts.env != nil {
+		cmd.Env = opts.env
+	}
 
 	if *verbosityLevel >= 1 {
 		fmt.Printf("Running: %+v\n", opts)
@@ -140,6 +145,7 @@ type rockerBuildOptions struct {
 	globalParams      []string
 	buildParams       []string
 	testLines         []string
+	env               []string
 	workdir           string
 	stdout            io.Writer
 	sha               *string
@@ -179,6 +185,7 @@ func runRockerBuildWithOptions(opts rockerBuildOptions) error {
 	output, err := runCmdWithOptions(cmdOptions{
 		command: getRockerBinaryPath(),
 		args:    args,
+		env:     opts.env,
 		workdir: opts.workdir,
 		stdout:  opts.stdout,
 	})
@@ -283,6 +290,13 @@ func debugf(format string, args ...interface{}) {
 	if *verbosityLevel >= 2 {
 		fmt.Printf(format, args...)
 	}
+}
+
+func rockerBuildEnv(envs ...string) []string {
+	baseEnv := []string{
+		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
+	}
+	return append(baseEnv, envs...)
 }
 
 type errCmdRun struct {


### PR DESCRIPTION
As reported in #104 fixed the following problems:
### 1. Build args values to shell interpolate into commands

``` Dockerfile
ARG deployenv=development
ENV DEPLOY_ENVIRONMENT=$deployenv
```
### 2. Use ENV variable values when --build-arg command-line param value omitted

``` bash
rocker build --build-arg NPM_TOKEN
```

Will use NPM_TOKEN env variable value in place of build-arg.

``` bash
rocker build --build-arg NPM_TOKEN=""
```

The value will be empty even if the env variable present.
