### PR TITLE
Add support for registries with basic auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,9 +73,9 @@ func main() {
 	app.Author = ""
 	app.Email = ""
 	app.Authors = []cli.Author{
-		{"Yura Bogdanov", "yuriy.bogdanov@grammarly.com"},
-		{"Stas Levental", "stas.levental@grammarly.com"},
-		{"Roman Khlystik", "roman.khlystik@grammarly.com"},
+		{Name: "Yura Bogdanov", Email: "yuriy.bogdanov@grammarly.com"},
+		{Name: "Stas Levental", Email: "stas.levental@grammarly.com"},
+		{Name: "Roman Khlystik", Email: "roman.khlystik@grammarly.com"},
 	}
 
 	app.Flags = append([]cli.Flag{

--- a/src/build/build.go
+++ b/src/build/build.go
@@ -185,7 +185,7 @@ func (b *Build) Run(plan Plan) (err error) {
 		}
 	}
 	if len(leftoverArgs) > 0 {
-		return fmt.Errorf("One or more build-args %v were not consumed, failing build.", leftoverArgs)
+		return fmt.Errorf("One or more build-args %v were not consumed, failing build", leftoverArgs)
 	}
 
 	return nil

--- a/src/build/commands.go
+++ b/src/build/commands.go
@@ -1021,7 +1021,7 @@ func (c *CommandMount) Execute(b *Build) (s State, err error) {
 		// MOUNT dir
 		case false:
 			if !path.IsAbs(arg) {
-				return s, fmt.Errorf("Invalid volume destination path: '%s', mount path must be absolute..", arg)
+				return s, fmt.Errorf("Invalid volume destination path: '%s', mount path must be absolute", arg)
 			}
 			c, err := b.getVolumeContainer(arg)
 			if err != nil {

--- a/src/dockerclient/registry.go
+++ b/src/dockerclient/registry.go
@@ -123,7 +123,14 @@ func registryGet(uri string, auth docker.AuthConfiguration, obj interface{}) (er
 		}
 		defer res.Body.Close()
 
-		b = parseBearer(res.Header.Get("Www-Authenticate"))
+		wwwAuthHdr := res.Header.Get("Www-Authenticate")
+
+		if strings.HasPrefix(wwwAuthHdr, "Basic ") {
+			req.SetBasicAuth(auth.Username, auth.Password)
+			continue
+		}
+
+		b = parseBearer(wwwAuthHdr)
 		log.Debugf("Got HTTP %d for %s; tried auth: %t; has Bearer: %t, auth username: %q", res.StatusCode, uri, authTry, b != nil, auth.Username)
 
 		if res.StatusCode == 401 && !authTry && b != nil {

--- a/src/dockerclient/registry.go
+++ b/src/dockerclient/registry.go
@@ -119,7 +119,7 @@ func registryGet(uri string, auth docker.AuthConfiguration, obj interface{}) (er
 
 	for {
 		if res, err = client.Do(req); err != nil {
-			return fmt.Errorf("Request to %s failed with %s\n", uri, err)
+			return fmt.Errorf("Request to %s failed with %s", uri, err)
 		}
 		defer res.Body.Close()
 
@@ -154,11 +154,11 @@ func registryGet(uri string, auth docker.AuthConfiguration, obj interface{}) (er
 	}
 
 	if body, err = ioutil.ReadAll(res.Body); err != nil {
-		return fmt.Errorf("Response from %s cannot be read due to error %s\n", uri, err)
+		return fmt.Errorf("Response from %s cannot be read due to error %s", uri, err)
 	}
 
 	if err = json.Unmarshal(body, obj); err != nil {
-		return fmt.Errorf("Response from %s cannot be unmarshalled due to error %s, response: %s\n",
+		return fmt.Errorf("Response from %s cannot be unmarshalled due to error %s, response: %s",
 			uri, err, string(body))
 	}
 
@@ -211,11 +211,11 @@ func getAuthToken(b *bearer, auth docker.AuthConfiguration) (token string, err e
 	}
 
 	if body, err = ioutil.ReadAll(res.Body); err != nil {
-		return "", fmt.Errorf("Response from %s cannot be read due to error %s\n", uri, err)
+		return "", fmt.Errorf("Response from %s cannot be read due to error %s", uri, err)
 	}
 
 	if err := json.Unmarshal(body, authResp); err != nil {
-		return "", fmt.Errorf("Response from %s cannot be unmarshalled due to error %s, response: %s\n",
+		return "", fmt.Errorf("Response from %s cannot be unmarshalled due to error %s, response: %s",
 			uri, err, body)
 	}
 

--- a/src/parser/line_parsers.go
+++ b/src/parser/line_parsers.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	errDockerfileNotStringArray = errors.New("When using JSON array syntax, arrays must be comprised of strings only.")
+	errDockerfileNotStringArray = errors.New("When using JSON array syntax, arrays must be comprised of strings only")
 )
 
 // ignore the current argument. This will still leave a command parsed, but


### PR DESCRIPTION
This PR fixes a bug when Rocker fails to list tags on private repositories with basic auth during `rocker build`. 

Merging this PR will probably fix #147.