### PR TITLE
Fix #182 cleanup export containers after build

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,6 +132,10 @@ func main() {
 			Name:  "reload-cache",
 			Usage: "removes any cache that hit and save the new one",
 		},
+		cli.BoolFlag{
+			Name:  "clean-exports",
+			Usage: "removes all containers and volumes used during build (prevents export cache but removes volumes leak)",
+		},
 		cli.StringFlag{
 			Name:  "cache-dir",
 			Value: "~/.rocker_cache",
@@ -385,6 +389,7 @@ func buildCommand(c *cli.Context) {
 		ID:            c.String("id"),
 		NoCache:       c.Bool("no-cache"),
 		ReloadCache:   c.Bool("reload-cache"),
+		CleanExports:  c.Bool("clean-exports"),
 		Push:          c.Bool("push"),
 		CacheDir:      cacheDir,
 		LogJSON:       c.GlobalBool("json"),

--- a/test/export_test.go
+++ b/test/export_test.go
@@ -397,3 +397,23 @@ func TestExport_DoubleExport(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestExport_NoExportContainerLeak(t *testing.T) {
+	rockerContent := `FROM alpine
+					  EXPORT /etc/issue issue
+
+					  FROM alpine
+					  IMPORT issue`
+
+	err := runRockerBuild(rockerContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCmd("docker", "ps", "-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotContains(t, "rocker_exports_", out)
+}


### PR DESCRIPTION
I was fed up of cleaning up rocker exports containers and volumes on our CI server, so I'm sending this PR.

When `rocker build` is used with `--clean-exports`, then all export/import containers and volumes are removed at the end of the build.

This isn't compatible with caching, so --clean-exports removes caching of EXPORT/IMPORT.
